### PR TITLE
Disable react-in-jsx-scope in .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,9 @@
       "jsx": true
     }
   },
+  globals: {
+    React: 'readable',
+  },
   "rules": {
     "no-console": "off",
     "linebreak-style": ["error", "unix"],


### PR DESCRIPTION
Next.js is exposing `React` as global variable so it doesn't have to be imported in every file - with this settings we can mute errors in ESLint for that.